### PR TITLE
Promeni od `strncpy_s()` vo `strncpy()`

### DIFF
--- a/bezKomentari/labs5z1.cpp
+++ b/bezKomentari/labs5z1.cpp
@@ -11,7 +11,8 @@ class velosipedist{
 
     public:
     velosipedist(const char *imePrez="",int god=0,int poeni=0){
-        strncpy_s(this->imePrez,imePrez,29);
+        strncpy(this->imePrez,imePrez,29);
+        this->imePrez[29] = '\0';
         this->god=god;this->poeni=poeni;
     }
 
@@ -34,8 +35,10 @@ class tim{
     
     public:
     tim(const char *ime="",const char *sponzor="",velosipedist *clenovi=NULL,int brNaClenovi=0){
-        strncpy_s(this->ime,ime,29);
-        strncpy_s(this->sponzor,sponzor,29);
+        strncpy(this->ime,ime,29);
+        this->ime[29] = '\0';
+        strncpy(this->sponzor,sponzor,29);
+        this->sponzor[29] = '\0';
         if(brNaClenovi<=maksClenovi){
             for(int i=0;i<brNaClenovi;i++)this->clenovi[i]=clenovi[i];
         }

--- a/bezKomentari/labs5z2.cpp
+++ b/bezKomentari/labs5z2.cpp
@@ -8,7 +8,8 @@ class kosarkar{
     int oPlata;
     public:
     kosarkar(const char *ime="",int oPlata=0){
-        strncpy_s(this->ime,ime,29);
+        strncpy(this->ime,ime,29);
+        this->ime[29] = '\0';
         this->oPlata=oPlata;
     }
 
@@ -28,7 +29,8 @@ class ekipa{
     public:
 
     ekipa(const char *ime="",int brNaKosarkari=0,int pPoeni=0,kosarkar *kosarkari=NULL){
-        strncpy_s(this->ime,ime,29);
+        strncpy(this->ime,ime,29);
+        this->ime[29] = '\0';
         if(brNaKosarkari>this->brNaKosarkari)this->brNaKosarkari=brNaKosarkari;
         if(pPoeni>this->pPoeni){
             this->pPoeni=pPoeni;

--- a/soKomentari/labs5z1kom.cpp
+++ b/soKomentari/labs5z1kom.cpp
@@ -12,7 +12,8 @@ class velosipedist{
     public:
     velosipedist(const char *imePrez="",int god=0,int poeni=0){//konstruktor moze odma da se
         //povika pri deklaracija na objekt
-        strncpy_s(this->imePrez,imePrez,29);//this konkretizira deka se misli na promenlivata
+        strncpy(this->imePrez,imePrez,29);//this konkretizira deka se misli na promenlivata
+        this->imePrez[29] = '\0'; // napravi manuelno null-terminiranje na nizata karakteri
         //koja pripaga na objektot a ne druga promenliva vo klasata
         this->god=god;this->poeni=poeni;//isto e kako da se vo posebni redovi samo zaso se
         //kratki gi staiv u ist red
@@ -37,8 +38,10 @@ class tim{
     
     public:
     tim(const char *ime="",const char *sponzor="",velosipedist *clenovi=NULL,int brNaClenovi=0){
-        strncpy_s(this->ime,ime,29);
-        strncpy_s(this->sponzor,sponzor,29);
+        strncpy(this->ime,ime,29);
+        this->ime[29] = '\0'; // napravi manuelno null-terminiranje na nizata karakteri
+        strncpy(this->sponzor,sponzor,29);
+        this->sponzor[29] = '\0'; // napravi manuelno null-terminiranje na nizata karakteri
         if(brNaClenovi<=maksClenovi){
             for(int i=0;i<brNaClenovi;i++)this->clenovi[i]=clenovi[i];
         }

--- a/soKomentari/labs5z2kom.cpp
+++ b/soKomentari/labs5z2kom.cpp
@@ -8,7 +8,8 @@ class kosarkar{
     int oPlata;
     public:
     kosarkar(const char *ime="",int oPlata=0){
-        strncpy_s(this->ime,ime,29);
+        strncpy(this->ime,ime,29);
+        this->ime[29] = '\0'; // napravi manuelno null-terminiranje na nizata karakteri
         this->oPlata=oPlata;
     }
 
@@ -28,7 +29,8 @@ class ekipa{
     public:
 
     ekipa(const char *ime="",int brNaKosarkari=0,int pPoeni=0,kosarkar *kosarkari=NULL){
-        strncpy_s(this->ime,ime,29);
+        strncpy(this->ime,ime,29);
+        this->ime[29] = '\0'; // napravi manuelno null-terminiranje na nizata karakteri
         if(brNaKosarkari>this->brNaKosarkari)this->brNaKosarkari=brNaKosarkari;
         if(pPoeni>this->pPoeni){
             this->pPoeni=pPoeni;


### PR DESCRIPTION
Na kratko kazhano, Microsoft ima napraeno svoja verzija od `strncpy`, imenuvana `strncpy_s`, so nekoi razliki:
- Preventiva na overflows
- Avtomatsko null-terminiranje
- Vrakja error code ako se sluci greska

Na Linux operativni sistemi (so GCC kompajler) i koj bilo drug kompajler (MinGW, MSYS2) na Windows, *osven* MSVC (Microsoft Visual C++), bez menuvanje od `strncpy_s()` vo `strncpy()` i bez manuelno null-terminiranje, **kodot nema da kompajlira**.

Fakultetot vo FLAOP koristi Linux pretezhno, pa ako nekoj ja zemi direktno zadachata od GitHub i proba da ja kompajlira, nema da mu raboti :skull: